### PR TITLE
fix the number of items in dropdown

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ async function getNotes(prefix: string): Promise<any[]> {
 			fields: ['id', 'title'],
 			order_by: 'updated_time',
 			order_dir: 'DESC',
-			limit: 10,
+			limit: 11,
 		});
 		return notes.items;
 	} else {


### PR DESCRIPTION
When entering `@@` only 9 items/notes are shown in the dropdown box.