### PR TITLE
CodeMirror 6 editor: Fix Quick Links conflict with other autocomplete plugins

### DIFF
--- a/src/contentScript/codeMirror6Plugin.ts
+++ b/src/contentScript/codeMirror6Plugin.ts
@@ -9,6 +9,7 @@ import type * as CodeMirrorStateType from '@codemirror/state';
 
 import type { CompletionContext, CompletionResult, Completion } from '@codemirror/autocomplete';
 import type { EditorView } from '@codemirror/view';
+import type { Extension } from '@codemirror/state';
 
 import { PluginContext } from './types';
 
@@ -93,10 +94,22 @@ export default function codeMirror6Plugin(pluginContext: PluginContext, CodeMirr
 		};
 	};
 
-	CodeMirror.addExtension([
-		autocompletion({
-			activateOnTyping: true,
+	let extension: Extension;
+
+	if (CodeMirror.joplinExtensions) {
+		extension = CodeMirror.joplinExtensions.completionSource(completeMarkdown);
+	} else {
+		// The override field doesn't work if there are multiple
+		// plugins that try to use autocomplete. As such, only use it
+		// if the Joplin autocomplete extension isn't available.
+		extension = autocompletion({
 			override: [ completeMarkdown ],
+		});
+	}
+
+	CodeMirror.addExtension([
+		extension,
+		autocompletion({
 			tooltipClass: () => 'quick-links-completions',
 		}),
 	]);


### PR DESCRIPTION
# Summary

Updates Quick Links to use `joplinExtensions.completionSource` for autocomplete. This fixes conflicts with the CodeMirror 6 Snippets plugin (and other future autocomplete plugins) without changing this plugin's behavior.

Fixes https://github.com/personalizedrefrigerator/joplin-plugin-codemirror-6-snippets/issues/1.

# Testing

1. Add Quick Links as a development plugin and CodeMirror 6 Snippets
2. Set up CodeMirror 6 Snippets using a snippets note.
3. Add a link using Quick Links.
4. CodeMirror 6 snippets to fill a snippet -- verify that it works and uses the same autocomplete window as Quick Links.
5. Create a JavaScript code block, type `@@function` and verify that the CodeMirror builtin completion for `function` can be used.
6. Verify that CodeMirror 6 snippets can also be used in the code block.

[Screen recording: Shows the above steps being tested on a Linux system](https://github.com/roman-r-m/joplin-plugin-quick-links/assets/46334387/89d0c019-abee-4676-9705-cfa29db3dcae)


